### PR TITLE
Use GameDatabase to read CelestialBodyColor

### DIFF
--- a/PlanetShine/Config.cs
+++ b/PlanetShine/Config.cs
@@ -134,23 +134,34 @@ namespace PlanetShine
 
             foreach (ConfigNode bodySettings in GameDatabase.Instance.GetConfigNodes("CelestialBodyColor"))
             {
-                CelestialBody body = FlightGlobals.Bodies.Find(n => n.name == bodySettings.GetValue("name"));
-                if (FlightGlobals.Bodies.Contains(body))
+                try
                 {
-                    Color color = ConfigNode.ParseColor(bodySettings.GetValue("color"))
-                        * float.Parse(bodySettings.GetValue("intensity"));
-                    color.r = (color.r / 255f);
-                    color.g = (color.g / 255f);
-                    color.b = (color.b / 255f);
-                    color.a = 1;
-                    if (!config.celestialBodyInfos.ContainsKey(body))
-                        config.celestialBodyInfos.Add(body, new CelestialBodyInfo
-                                                      (
-                                                       color,
-                                                       float.Parse(bodySettings.GetValue("intensity")),
-                                                       float.Parse(bodySettings.GetValue("atmosphereAmbient")),
-                                                       float.Parse(bodySettings.GetValue("groundAmbientOverride"))
-                                                       ));
+                    CelestialBody body = FlightGlobals.Bodies.Find(n => n.name == bodySettings.GetValue("name"));
+                    if (FlightGlobals.Bodies.Contains(body))
+                    {
+                        Color color = ConfigNode.ParseColor(bodySettings.GetValue("color"))
+                            * float.Parse(bodySettings.GetValue("intensity"));
+                        color.r = (color.r / 255f);
+                        color.g = (color.g / 255f);
+                        color.b = (color.b / 255f);
+                        color.a = 1;
+                        if (!config.celestialBodyInfos.ContainsKey(body))
+                            config.celestialBodyInfos.Add(body, new CelestialBodyInfo
+                                                          (
+                                                           color,
+                                                           float.Parse(bodySettings.GetValue("intensity")),
+                                                           float.Parse(bodySettings.GetValue("atmosphereAmbient")),
+                                                           float.Parse(bodySettings.GetValue("groundAmbientOverride"))
+                                                           ));
+                    }
+                }
+                catch(Exception e)
+                {
+                    Debug.LogError(String.Format(
+                        "[PlanetShine] An exception occured reading CelestialBodyColor node:\n{0}\nThe exception was:\n{1}",
+                        bodySettings,
+                        e
+                    ));
                 }
             }
         }

--- a/PlanetShine/Config.cs
+++ b/PlanetShine/Config.cs
@@ -113,7 +113,6 @@ namespace PlanetShine
         {
             configFile = ConfigNode.Load(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Config/Settings.cfg");
             configFileNode = configFile.GetNode("PlanetShine");
-            var celestialBodies = ConfigNode.Load(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Config/CelestialBodies.cfg");
 
             if (bool.Parse (configFileNode.GetValue ("useAreaLight")))
                 config.albedoLightsQuantity = Config.maxAlbedoLightsQuantity;
@@ -133,7 +132,7 @@ namespace PlanetShine
             config.updateFrequency = int.Parse(configFileNode.GetValue("updateFrequency"));
             config.setQuality(int.Parse(configFileNode.GetValue("quality")));
 
-            foreach (ConfigNode bodySettings in celestialBodies.GetNodes("CelestialBodyColor"))
+            foreach (ConfigNode bodySettings in GameDatabase.Instance.GetConfigNodes("CelestialBodyColor"))
             {
                 CelestialBody body = FlightGlobals.Bodies.Find(n => n.name == bodySettings.GetValue("name"));
                 if (FlightGlobals.Bodies.Contains(body))


### PR DESCRIPTION
Hi,

This is a simple change that makes PlanetShine use KSP's GameDatabase to read `CelestialBodyColor` nodes, rather than reading them from a hardcoded file. This allows `CelestialBodyColor` nodes to be read from _any_ `.cfg` file in the `GameData` directory. This also means that the configuration can be altered by other mods using Module Manager patches.

The impetus behind this change is my reworking of the Outer Planets Mod CKAN metadata in KSP-CKAN/NetKAN#1188. Outer Planets Mod distributes a `CelestialBodies.cfg`, which overwrites PlanetShine's default one. This causes a fair bit of gymnastics to get the two mods to play well together in CKAN. With this change, Outer Planets Mod will be able to distribute their own `CelestialBodies.cfg` completely independent of PlanetShine's and with only the additional bodies that they add.
