### PR TITLE
Fix NullReference error in logs

### DIFF
--- a/PlanetShine/Gui.cs
+++ b/PlanetShine/Gui.cs
@@ -430,7 +430,8 @@ namespace PlanetShine
             Logger.Log("Gui->OnDestroy");
             if (stockButton != null)
                 ApplicationLauncher.Instance.RemoveModApplication(stockButton);
-            blizzyButton.Destroy();
+            if (blizzyButton != null)
+                blizzyButton.Destroy();
         }
     }
 }


### PR DESCRIPTION
Fixes a somewhat harmless NullReference error that appears in the log output when not using Blizzy's toolbar.
