### PR TITLE
KSP 1.1.3 update & MM compatibility

### DIFF
--- a/PlanetShine.version
+++ b/PlanetShine.version
@@ -13,24 +13,24 @@
         "MAJOR":0,
         "MINOR":2,
         "PATCH":5,
-        "BUILD":0
+        "BUILD":1
     },
     "KSP_VERSION":
     {
         "MAJOR":1,
         "MINOR":1,
-        "PATCH":0
+        "PATCH":3
     },
     "KSP_VERSION_MIN":
     {
         "MAJOR":1,
         "MINOR":1,
-        "PATCH":0
+        "PATCH":3
     },
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
         "MINOR":1,
-        "PATCH":0
+        "PATCH":3
     }
 } 

--- a/PlanetShine/Config.cs
+++ b/PlanetShine/Config.cs
@@ -124,7 +124,7 @@ namespace PlanetShine
             
         public void LoadSettings()
         {
-            configFile = ConfigNode.Load(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Config/Settings.cfg");
+            configFile = ConfigNode.Load(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Plugins/PluginData/Settings.cfg");
             configFileNode = configFile.GetNode("PlanetShine");
 
             if (bool.Parse (configFileNode.GetValue ("useAreaLight")))
@@ -206,9 +206,8 @@ namespace PlanetShine
             configFileNode.SetValue("updatefrequency", config.updateFrequency.ToString());
             configFileNode.SetValue("quality", config.quality.ToString());
             configFileNode.SetValue("stockToolbarEnabled", config.stockToolbarEnabled ? "True" : "False");
-            configFile.Save(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Config/Settings.cfg");
+            configFile.Save(KSPUtil.ApplicationRootPath + "GameData/PlanetShine/Plugins/PluginData/Settings.cfg");
         }
 
     }
 }
-

--- a/PlanetShine/Gui/GuiRenderer.cs
+++ b/PlanetShine/Gui/GuiRenderer.cs
@@ -40,7 +40,7 @@ namespace PlanetShine
         public bool Render(PlanetShine planetShine)
         {
             configWindowPosition = GUILayout.Window(143751300, configWindowPosition,
-                                         OnConfigWindow, "PlanetShine 0.2.5.0 - Beta", windowStyle);
+                                         OnConfigWindow, "PlanetShine 0.2.5.1 - Beta", windowStyle);
             if (config.debug && PlanetShine.Instance != null)
             {
                 debugWindowPosition = GUILayout.Window(143751301, debugWindowPosition,


### PR DESCRIPTION
- Update the version number for a new KSP 1.1.3 release (hopefully it is correct!).
- Move the settings under the PluginData folder so that Module Manager will not discard the cache and force a rebuild every time that a change is made.
